### PR TITLE
GEN-1909 Add secret_manager.setSecret to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ event = wayscript.context.getEvent();
 console.log(event);
 ```
 
+## Secrets
+
+To create a new secret, or update an existing one:
+```
+const wayscript = require("wayscript");
+wayscript.secret_manager.setSecret("my_key", "my_secret_value");
+```
+
 More use cases in can be found [here](example.js) 
 
 Contributing guide [here](CONTRIBUTING.md)

--- a/src/secret_manager.js
+++ b/src/secret_manager.js
@@ -14,7 +14,7 @@ function setSecret(secret_key, secret_val){
         if (responseStatus == 403) {
             jsonResponseData = {error: "user is not authorized to modify lair"};
         }
-        throw `{"status":"${responseStatus}","json":"${JSON.stringify(jsonResponseData)}"}`;
+        throw `{"status":"${responseStatus}","json":${JSON.stringify(jsonResponseData)}}`;
     }
     return jsonResponseData;
 }

--- a/src/secret_manager.js
+++ b/src/secret_manager.js
@@ -2,13 +2,13 @@ const utils = require("./utils");
 const context = require("./context");
 
 function setSecret(secret_key, secret_val){
-    let process = context.getProcess();
-    let lairId = process.lair_id;
+    const process = context.getProcess();
+    const lairId = process.lair_id;
 
-    let client = new utils.WayScriptClient();
-    let response = client.setLairSecret(lairId, secret_key, secret_val);
+    const client = new utils.WayScriptClient();
+    const response = client.setLairSecret(lairId, secret_key, secret_val);
 
-    let responseStatus = response[0];
+    const responseStatus = response[0];
     let jsonResponseData = response[1];
     if (!(200 <= responseStatus && responseStatus <=299)) {
         if (responseStatus == 403) {

--- a/src/secret_manager.js
+++ b/src/secret_manager.js
@@ -14,7 +14,7 @@ function setSecret(secret_key, secret_val){
         if (responseStatus == 403) {
             jsonResponseData = {error: "user is not authorized to modify lair"};
         }
-        throw `{"status": "${responseStatus}", "json": "${jsonResponseData}"}`;
+        throw `{"status": "${responseStatus}", "json": "${JSON.stringify(jsonResponseData)}"}`;
     }
     return jsonResponseData;
 }

--- a/src/secret_manager.js
+++ b/src/secret_manager.js
@@ -1,0 +1,23 @@
+const utils = require("./utils");
+const context = require("./context");
+
+function setSecret(secret_key, secret_val){
+    let process = context.getProcess();
+    let lairId = process.lair_id;
+
+    let client = new utils.WayScriptClient();
+    let response = client.setLairSecret(lairId, secret_key, secret_val);
+
+    let responseStatus = response[0];
+    let jsonResponseData = response[1];
+    if (!(200 <= responseStatus && responseStatus <=299)) {
+        if (responseStatus == 403) {
+            jsonResponseData = {error: "user is not authorized to modify lair"};
+        }
+        throw `{"status": "${responseStatus}", "json": "${jsonResponseData}"}`;
+    }
+    return jsonResponseData;
+}
+
+
+module.exports = {setSecret}

--- a/src/secret_manager.js
+++ b/src/secret_manager.js
@@ -14,7 +14,7 @@ function setSecret(secret_key, secret_val){
         if (responseStatus == 403) {
             jsonResponseData = {error: "user is not authorized to modify lair"};
         }
-        throw `{"status": "${responseStatus}", "json": "${JSON.stringify(jsonResponseData)}"}`;
+        throw `{"status":"${responseStatus}","json":"${JSON.stringify(jsonResponseData)}"}`;
     }
     return jsonResponseData;
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,11 +1,13 @@
 const WAYSCRIPT_ORIGIN = process.env.WAYSCRIPT_ORIGIN || "https://api.wayscript.com";
 
-const PROCESSES_ROUTE = "processes";
+const FILES_ROUTE = "files";
 const LAIRS_ROUTE = "lairs";
+const PROCESSES_ROUTE = "processes";
 const WEBHOOKS_ROUTE = "webhooks";
 const WORKSPACES_ROUTE = "workspaces";
 
 const ROUTES = {
+    files: {"set_secret": FILES_ROUTE + "/laids/$id/secrets"},
     lairs: {"detail": LAIRS_ROUTE + "/$id"},
     processes: {"detail_expanded": PROCESSES_ROUTE + "/$id/detail"},
     webhooks: {"http_trigger_response": WEBHOOKS_ROUTE + "/http-trigger/response/$id"},

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,12 @@ class WayScriptClient {
         return this.executeRequest('GET', url, null, headers);
     }
 
+    setLairSecret(_id, _secretKey, _secretValue) {
+        let url = this.buildURLEndpoint("files","set_secret",{id: _id});
+        let payload = {key: _secretKey, value: _secretValue};
+        return this.executeRequest('POST', url, payload);
+    }
+
     buildURLEndpoint(subpath, route, templateArgs) {
         let subpathEndpoint = settings.ROUTES[subpath][route];
         for (const arg in templateArgs) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,8 +51,8 @@ class WayScriptClient {
     }
 
     setLairSecret(_id, _secretKey, _secretValue) {
-        let url = this.buildURLEndpoint("files","set_secret",{id: _id});
-        let payload = {key: _secretKey, value: _secretValue};
+        const url = this.buildURLEndpoint("files","set_secret",{id: _id});
+        const payload = {key: _secretKey, value: _secretValue};
         return this.executeRequest('POST', url, payload);
     }
 

--- a/src/wayscript.js
+++ b/src/wayscript.js
@@ -1,5 +1,6 @@
 const context = require('./context');
 const http_trigger = require('./triggers/http_trigger');
+const secret_manager = require('./secret_manager');
 const utils = require('./utils');
 
-module.exports = { context, http_trigger, utils };
+module.exports = { context, secret_manager, http_trigger, utils };

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -15,21 +15,27 @@ test('Set Secret returns no info on success', () => {
 
 test('Set Secret returns passed error message on 404', () => {
     let error = {error: "wayscript backend error message"};
-    let result = {status: "404", json: error}
+    let result = {status: "404", json: error};
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
     try {
-        secret_manager.setSecret("test_key", "test_value")
+        secret_manager.setSecret("test_key", "test_value");
     } catch (err) {
-        expect(err).toEqual(JSON.stringify(result))
-        return  // short circuit
+        expect(err).toEqual(JSON.stringify(result));
+        return;  // short circuit
     }
-    expect(true).toEqual(false)  // fail if no error thrown
+    expect(true).toEqual(false);  // fail if no error thrown
 });
 
 test('Set Secret returns unique error message on 403', () => {
     let result = {status: "403", json: {error: "user is not authorized to modify lair"}};
 
-    jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [403, {}])
-    expect(secret_manager.setSecret("test_key", "test_value")).toThrow(result);
+    jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [403, {}]);
+    try {
+        secret_manager.setSecret("test_key", "test_value");
+    } catch(err) {
+        expect(err).toEqual(JSON.stringify(result));
+        return;  // short circuit
+    }
+    expect(true).toEqual(false);  // fail if no error thrown
 });

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -7,15 +7,15 @@ jest.mock("../src/context");
 context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`);
 
 test('Set Secret returns no info on success', () => {
-    let payload = {};
+    const payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
     expect(secret_manager.setSecret("test_key", "test_value")).toEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {
-    let error = {error: "wayscript backend error message"};
-    let result = {status: "404", json: error};
+    const error = {error: "wayscript backend error message"};
+    const result = {status: "404", json: error};
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
     try {
@@ -28,7 +28,7 @@ test('Set Secret returns passed error message on 404', () => {
 });
 
 test('Set Secret returns unique error message on 403', () => {
-    let result = {status: "403", json: {error: "user is not authorized to modify lair"}};
+    const result = {status: "403", json: {error: "user is not authorized to modify lair"}};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [403, {}]);
     try {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -18,14 +18,12 @@ test('Set Secret returns passed error message on 404', () => {
     let result = {status: "404", json: error}
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
-    expect(secret_manager.setSecret("test_key", "test_value")).toEqual(result)
-    //expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
+    expect(secret_manager.setSecret("test_key", "test_value")).toThrow(result);
 });
 
 test('Set Secret returns unique error message on 403', () => {
-    //let error = {error: "user is not authorized to modify lair"};
     let result = {status: "403", json: {error: "user is not authorized to modify lair"}};
 
-    utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [403, {}])
-    expect(secret_manager.setSecret("test_key", "test_value")).toEqual(result);
+    jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [403, {}])
+    expect(secret_manager.setSecret("test_key", "test_value")).toThrow(result);
 });

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,8 +10,7 @@ test('Set Secret returns no info on success', () => {
     let payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
-    let test_fn = () => { secret_manager.setSecret("test_key", "test_value") }
-    expect(test_fn).toEqual(payload);
+    expect(secret_manager.setSecret("test_key", "test_value")).toEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -3,8 +3,8 @@ const utils = require("../src/utils");
 const context = require("../src/context");
 
 // Set up standard mocks
-jest.mock("utils");
-jest.mock("context");
+jest.mock("../src/utils");
+jest.mock("../src/context");
 context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`)
 
 test.skip('Set Secret returns no info on success', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -18,13 +18,14 @@ test('Set Secret returns passed error message on 404', () => {
     let result = {status: "404", json: error}
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
-    expect(() => { JSON.parse(secret_manager.setSecret("test_key", "test_value")) }).toStrictEqual(result)
+    expect(secret_manager.setSecret("test_key", "test_value")).toEqual(result)
     //expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
 });
 
 test('Set Secret returns unique error message on 403', () => {
     //let error = {error: "user is not authorized to modify lair"};
+    let result = {status: "403", json: {error: "user is not authorized to modify lair"}};
 
     utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [403, {}])
-    expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{ "Success" : "False", "Status" : "403"}`));
+    expect(secret_manager.setSecret("test_key", "test_value")).toEqual(result);
 });

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -3,7 +3,6 @@ const utils = require("../src/utils");
 const context = require("../src/context");
 
 // Set up standard mocks
-jest.mock("../src/utils");
 jest.mock("../src/context");
 context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`);
 

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -21,7 +21,7 @@ test('Set Secret returns passed error message on 404', () => {
     try {
         secret_manager.setSecret("test_key", "test_value")
     } catch (err) {
-        expect(err).toEqual(result)
+        expect(err).toEqual(JSON.stringify(result))
         return  // short circuit
     }
     expect(true).toEqual(false)  // fail if no error thrown

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -7,7 +7,7 @@ jest.mock("../src/context");
 context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`);
 
 test('Set Secret returns no info on success', () => {
-    let payload = {};
+    let payload = `{ }`;
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
@@ -16,7 +16,7 @@ test('Set Secret returns no info on success', () => {
 test('Set Secret returns passed error message on 404', () => {
     let error = {error: "wayscript backend error message"};
     
-    utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [404, error])
+    jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
     expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
 });
 

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -22,9 +22,9 @@ test('Set Secret returns passed error message on 404', () => {
         secret_manager.setSecret("test_key", "test_value")
     } catch (err) {
         expect(JSON.parse(err)).toEqual(result)
-        return
+        return  // short circuit
     }
-    expect(true).toEqual(false)
+    expect(true).toEqual(false)  // fail if no error thrown
 });
 
 test('Set Secret returns unique error message on 403', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -7,32 +7,26 @@ jest.mock("../src/utils");
 jest.mock("../src/context");
 context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`)
 
-test.skip('Set Secret returns no info on success', () => {
+test('Set Secret returns no info on success', () => {
     let payload = {};
 
     let client = new utils.WayScriptClient()
     client.setLairSecret.mockImplementationOnce(() => [200, payload])
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
 });
-/*
-test.skip('Set Secret returns passed error message on 404', () => {
+
+test('Set Secret returns passed error message on 404', () => {
     let error = {error: "wayscript backend error message"};
     
-    let spy404 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation(() => {
-        return [404, error]
-    });
+    let client = new utils.WayScriptClient()
+    client.setLairSecret.mockImplementationOnce(() => [404, error])
     expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
-    spy404.mockRestore();
 });
 
-test.skip('Set Secret returns unique error message on 403', () => {
+test('Set Secret returns unique error message on 403', () => {
     let error = {error: "user is not authorized to modify lair"};
 
-    let spy403 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation(() => {
-        return [403, {}]
-    });
+    let client = new utils.WayScriptClient()
+    client.setLairSecret.mockImplementationOnce(() => [403, {}])
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{ "Success" : "False", "Status" : "403"}`));
-    //expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{"status" : "403", "json" : ${error}"}`));
-    spy403.mockRestore();
 });
-*/

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -5,7 +5,7 @@ const context = require("../src/context");
 // Set up standard mocks
 jest.mock("utils");
 jest.mock("context");
-context.getProcess.mockImplementation(() => {lair_id: "fake_lair_id"})
+context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`)
 
 test.skip('Set Secret returns no info on success', () => {
     let payload = {};

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -5,12 +5,12 @@ const context = require("../src/context");
 // Set up standard mocks
 jest.mock("../src/utils");
 jest.mock("../src/context");
-context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`)
+context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`);
 
 test('Set Secret returns no info on success', () => {
     let payload = {};
 
-    utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [200, payload])
+    jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
 });
 

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -7,17 +7,19 @@ jest.mock("../src/context");
 context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`);
 
 test('Set Secret returns no info on success', () => {
-    let payload = `{ }`;
+    let payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
-    expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
+    expect(JSON.parse(() => { secret_manager.setSecret("test_key", "test_value") })).toStrictEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {
     let error = {error: "wayscript backend error message"};
+    let result = {status: "404", json: error}
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
-    expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
+    expect(JSON.parse(() => { secret_manager.setSecret("test_key", "test_value") })).toStrictEqual(result)
+    //expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
 });
 
 test('Set Secret returns unique error message on 403', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,7 +10,7 @@ test('Set Secret returns no info on success', () => {
     let payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
-    expect(JSON.parse(() => { secret_manager.setSecret("test_key", "test_value") })).toStrictEqual(payload);
+    expect(() => { JSON.parse(secret_manager.setSecret("test_key", "test_value")) }).toStrictEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {
@@ -18,7 +18,7 @@ test('Set Secret returns passed error message on 404', () => {
     let result = {status: "404", json: error}
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
-    expect(JSON.parse(() => { secret_manager.setSecret("test_key", "test_value") })).toStrictEqual(result)
+    expect(() => { JSON.parse(secret_manager.setSecret("test_key", "test_value")) }).toStrictEqual(result)
     //expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
 });
 

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -1,0 +1,32 @@
+const secret_manager = require("../src/secret_manager");
+
+test.skip('Set Secret returns no info on success', () => {
+    let payload = {};
+
+    let spy200 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation((url) => {
+        return [200, payload];
+    });
+    expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
+    spy200.mockRestore();
+});
+
+test.skip('Set Secret returns passed error message on 404', () => {
+    let error = {error: "wayscript backend error message"};
+    
+    let spy404 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation((url) => {
+        return [404, error]
+    });
+    expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
+    spy404.mockRestore();
+});
+
+test.skip('Set Secret returns unique error message on 403', () => {
+    let error = {error: "user is not authorized to modify lair"};
+
+    let spy403 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation((url) => {
+        return [403, {}]
+    });
+    expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{ "Success" : "False", "Status" : "403"}`));
+    //expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{"status" : "403", "json" : ${error}"}`));
+    spy403.mockRestore();
+});

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -18,7 +18,7 @@ test('Set Secret returns passed error message on 404', () => {
     let result = {status: "404", json: error}
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
-    expect(secret_manager.setSecret("test_key", "test_value")).toThrow(result);
+    expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow(result);
 });
 
 test('Set Secret returns unique error message on 403', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,7 +10,7 @@ test('Set Secret returns no info on success', () => {
     let payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
-    expect(() => { JSON.parse(secret_manager.setSecret("test_key", "test_value")) }).toStrictEqual(payload);
+    expect(JSON.parse(secret_manager.setSecret("test_key", "test_value"))).toStrictEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,7 +10,8 @@ test('Set Secret returns no info on success', () => {
     let payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
-    expect(JSON.parse(secret_manager.setSecret("test_key", "test_value"))).toStrictEqual(payload);
+    let test_fn = () => { JSON.parse(secret_manager.setSecret("test_key", "test_value")) }
+    expect(test_fn()).toStrictEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -11,7 +11,7 @@ test('Set Secret returns no info on success', () => {
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
     let test_fn = () => { secret_manager.setSecret("test_key", "test_value") }
-    expect(test_fn()).toEqual(payload);
+    expect(test_fn).toEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -24,7 +24,7 @@ test('Set Secret returns passed error message on 404', () => {
 });
 
 test('Set Secret returns unique error message on 403', () => {
-    let error = {error: "user is not authorized to modify lair"};
+    //let error = {error: "user is not authorized to modify lair"};
 
     let client = new utils.WayScriptClient()
     client.setLairSecret.mockImplementationOnce(() => [403, {}])

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -18,7 +18,13 @@ test('Set Secret returns passed error message on 404', () => {
     let result = {status: "404", json: error}
     
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [404, error]);
-    expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow(result);
+    try {
+        secret_manager.setSecret("test_key", "test_value")
+    } catch (err) {
+        expect(JSON.parse(err)).toEqual(result)
+        return
+    }
+    expect(true).toEqual(false)
 });
 
 test('Set Secret returns unique error message on 403', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -1,19 +1,25 @@
 const secret_manager = require("../src/secret_manager");
+const utils = require("../src/utils");
+const context = require("../src/context");
+
+// Set up standard mocks
+jest.mock("utils");
+jest.mock("context");
+context.getProcess.mockImplementation(() => {lair_id: "fake_lair_id"})
 
 test.skip('Set Secret returns no info on success', () => {
     let payload = {};
 
-    let spy200 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation((url) => {
-        return [200, payload];
-    });
+    client = new utils.WayScriptClient()
+    client.setLairSecret.mock([200, payload])
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
     spy200.mockRestore();
 });
-
+/*
 test.skip('Set Secret returns passed error message on 404', () => {
     let error = {error: "wayscript backend error message"};
     
-    let spy404 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation((url) => {
+    let spy404 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation(() => {
         return [404, error]
     });
     expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
@@ -23,10 +29,11 @@ test.skip('Set Secret returns passed error message on 404', () => {
 test.skip('Set Secret returns unique error message on 403', () => {
     let error = {error: "user is not authorized to modify lair"};
 
-    let spy403 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation((url) => {
+    let spy403 = jest.spyOn(wayscriptClient,'executeRequest').mockImplementation(() => {
         return [403, {}]
     });
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{ "Success" : "False", "Status" : "403"}`));
     //expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{"status" : "403", "json" : ${error}"}`));
     spy403.mockRestore();
 });
+*/

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,23 +10,20 @@ context.getProcess.mockImplementation(() => `{"lair_id": "fake_lair_id"}`)
 test('Set Secret returns no info on success', () => {
     let payload = {};
 
-    let client = new utils.WayScriptClient()
-    client.setLairSecret.mockImplementationOnce(() => [200, payload])
+    utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [200, payload])
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
 });
 
 test('Set Secret returns passed error message on 404', () => {
     let error = {error: "wayscript backend error message"};
     
-    let client = new utils.WayScriptClient()
-    client.setLairSecret.mockImplementationOnce(() => [404, error])
+    utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [404, error])
     expect(() => { secret_manager.setSecret("test_key", "test_value") }).toThrow("wayscript backend error message");
 });
 
 test('Set Secret returns unique error message on 403', () => {
     //let error = {error: "user is not authorized to modify lair"};
 
-    let client = new utils.WayScriptClient()
-    client.setLairSecret.mockImplementationOnce(() => [403, {}])
+    utils.WayScriptClient.setLairSecret.mockImplementationOnce(() => [403, {}])
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(`{ "Success" : "False", "Status" : "403"}`));
 });

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,10 +10,9 @@ context.getProcess.mockImplementation(() => {lair_id: "fake_lair_id"})
 test.skip('Set Secret returns no info on success', () => {
     let payload = {};
 
-    client = new utils.WayScriptClient()
-    client.setLairSecret.mock([200, payload])
+    let client = new utils.WayScriptClient()
+    client.setLairSecret.mockImplementationOnce(() => [200, payload])
     expect(secret_manager.setSecret("test_key", "test_value")).toStrictEqual(JSON.parse(payload));
-    spy200.mockRestore();
 });
 /*
 test.skip('Set Secret returns passed error message on 404', () => {

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -21,7 +21,7 @@ test('Set Secret returns passed error message on 404', () => {
     try {
         secret_manager.setSecret("test_key", "test_value")
     } catch (err) {
-        expect(JSON.parse(err)).toEqual(result)
+        expect(err).toEqual(result)
         return  // short circuit
     }
     expect(true).toEqual(false)  // fail if no error thrown

--- a/test/secret_manager.test.js
+++ b/test/secret_manager.test.js
@@ -10,8 +10,8 @@ test('Set Secret returns no info on success', () => {
     let payload = {};
 
     jest.spyOn(utils.WayScriptClient.prototype, "setLairSecret").mockImplementationOnce(() => [200, payload]);
-    let test_fn = () => { JSON.parse(secret_manager.setSecret("test_key", "test_value")) }
-    expect(test_fn()).toStrictEqual(payload);
+    let test_fn = () => { secret_manager.setSecret("test_key", "test_value") }
+    expect(test_fn()).toEqual(payload);
 });
 
 test('Set Secret returns passed error message on 404', () => {


### PR DESCRIPTION
## Change description

> New SDK function, allows process running on wayscript to create or update a secret
```
const wayscript = require("wayscript");
wayscript.secret_manager.setSecret("my_key", "my_secret_value");
```

## Checklist

- [x] Application changes have been tested and automated tests have been added, if applicable
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

## Related issues

> Fixes GEN-1909
